### PR TITLE
fix: 切换语言时 language.ini 膨胀出一堆空行/回车

### DIFF
--- a/INIBrowser/IBR_Localization.cpp
+++ b/INIBrowser/IBR_Localization.cpp
@@ -248,7 +248,7 @@ namespace IBR_L10n
                 else S.replace(Pos, LineEnd - Pos, NewLine);
 
                 ExtFileClass E;
-                if (E.Open(LanguageININame.c_str(), L"w"))
+                if (E.Open(LanguageININame.c_str(), L"wb"))
                 {
                     E.PutStr(S);
                     E.Close();

--- a/INIBrowser/IBR_Localization.cpp
+++ b/INIBrowser/IBR_Localization.cpp
@@ -234,24 +234,24 @@ namespace IBR_L10n
 
         if (!LanguageININame.empty())
         {
+            // 仅替换 [Basic] 段 CurrentLanguage= 行的语言值，其余字节（含原始换行 CRLF/LF）原样保留。
+            // 旧实现用 GetLines(S,false) 会先把每个 \r 与 \n 分别置 0，且 false 不跳过空段，
+            // 导致 CRLF 的每个换行在 \r、\n 位置各产生一个空行，逐行写回后 language.ini 每次切换都膨胀出一堆空行/回车。
             auto S = GetStringFromFile(LanguageININame.c_str());
-            auto L = GetLines(std::move(S), false);
-            ExtFileClass E;
-            E.Open(LanguageININame.c_str(), L"w");
-            for (auto& l : L)
+            const std::string Needle = "CurrentLanguage=";
+            auto Pos = S.find(Needle);  // 首处即 [Basic]CurrentLanguage=（Error_LanguageKeyNotFound 值中不含 '='）
+            if (Pos != std::string::npos)
             {
-                auto t = IniToken(l, false);
-                if (!t.IsSection && t.Key == "CurrentLanguage")
+                auto LineEnd = S.find_first_of("\r\n", Pos);
+                auto NewLine = "CurrentLanguage=" + Language;
+                if (LineEnd == std::string::npos) S.replace(Pos, std::string::npos, NewLine);
+                else S.replace(Pos, LineEnd - Pos, NewLine);
+
+                ExtFileClass E;
+                if (E.Open(LanguageININame.c_str(), L"w"))
                 {
-                    std::string dst(l);
-                    subreplace(dst, CurrentLanguage, Language);
-                    E.PutStr(dst);
-                    E.Ln();
-                }
-                else
-                {
-                    E.PutStr(l);
-                    E.Ln();
+                    E.PutStr(S);
+                    E.Close();
                 }
             }
         }


### PR DESCRIPTION
## 问题

切换语言后 language.ini 会逐次膨胀出一堆空行/回车。

## 根因

\IBR_Localization.cpp\ 的 \SetLanguage\ 使用 \GetLines(S, false)\ 逐行读写文件来更新 \CurrentLanguage\：

- \GetLines(S, false)\ 会先把每个 \\\r\ 与 \\\n\ 分别置 0；
- \alse\ 不跳过空段，导致 CRLF 的每个换行在 \\\r\、\\\n\ 位置各产生一个空行；
- 逐行写回后，每次切换语言 language.ini 就膨胀出一堆空行/回车。

## 修复

改为在原始文件文本中直接整串替换 \[Basic] CurrentLanguage=\ 的取值，其余字节（含原始换行 CRLF/LF）原样保留写回，不再产生多余空行。